### PR TITLE
[IMP] mount current user's $home as /root in docker

### DIFF
--- a/bash-script/ak.sh
+++ b/bash-script/ak.sh
@@ -57,7 +57,7 @@ if [ "$(pwd)" != '/' ]; then
 fi
 
 if [ -n "$HOME" ]; then
-    VOLUMES="$VOLUMES -v $HOME:$HOME" # mount $HOME in $HOME[/root] to share docker.config and the docky files
+    VOLUMES="$VOLUMES -v $HOME:/root" # mount $HOME in $HOME[/root] to share docker.config and the docky files
 fi
 
 # Only allocate tty if we detect one


### PR DESCRIPTION
the script within the container runs as root, so to keep docky's settings, you need to mount it as /root in the container, not at the place the calling user's home directory would be. That's the change we did locally to make builds with merges work.

But actually I'd rather add

```dockerfile
RUN git config --system user.name "Your Name"; git config --system user.email "youremail@yourdomain.com"
```

to the Dockerfile here, so that git merges work for any user within the container, and you don't need to configure git outside of the container at all.

ping @whulshof @Stephanvandenberg 